### PR TITLE
Loads the recorder asynchronously.

### DIFF
--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -27,7 +27,7 @@ namespace RePlays.Recorders {
 
         static signal_callback_t outputStopCb;
 
-        public override void Start() {
+        public override async void Start() {
             if (Connected) return;
 
             // STARTUP

--- a/Classes/Services/RecordingService.cs
+++ b/Classes/Services/RecordingService.cs
@@ -25,7 +25,7 @@ namespace RePlays.Services {
             }
         }
 
-        public static void Start(Type type) {
+        public async static void Start(Type type) {
             DetectionService.LoadDetections();
 
             if (ActiveRecorder == null) {
@@ -36,7 +36,7 @@ namespace RePlays.Services {
                 }
 
                 ActiveRecorder = new LibObsRecorder();
-                ActiveRecorder.Start();
+                await Task.Run(() => ActiveRecorder.Start());
             }
         }
 


### PR DESCRIPTION
Makes the application feel snappier when launching it (and removes the 2-3 second freeze).