### PR TITLE
Style: Settings page improvement

### DIFF
--- a/Classes/Services/Hotkeys/BookmarkHotkey.cs
+++ b/Classes/Services/Hotkeys/BookmarkHotkey.cs
@@ -1,15 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms;
-using RePlays.Services;
+﻿using RePlays.Services;
 
 namespace RePlays.Classes.Services.Hotkeys
 {
     public class BookmarkHotkey : Hotkey
     {
+        private readonly string key = "CreateBookmark";
         public override void Action()
         {
             if (RecordingService.IsRecording) BookmarkService.AddBookmark();
@@ -18,8 +13,8 @@ namespace RePlays.Classes.Services.Hotkeys
         protected override void SetKeybind()
         {
             string[] keybind;
-            SettingsService.Settings.keybindings.TryGetValue("CreateBookmark", out keybind);
-            _keybind = ParseKeys(keybind);
+            SettingsService.Settings.keybindings.TryGetValue(key, out keybind);
+            _keybind = ParseKeys(key, keybind);
         }
     }
 }

--- a/Classes/Services/Hotkeys/Hotkey.cs
+++ b/Classes/Services/Hotkeys/Hotkey.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography.Xml;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Microsoft.Web.WebView2.Core;
+using RePlays.Services;
 
 namespace RePlays.Classes.Services.Hotkeys
 {
@@ -14,14 +16,22 @@ namespace RePlays.Classes.Services.Hotkeys
         protected Keys _keybind;
         public Keys Keybind => _keybind;
 
+        private static Dictionary<string, string[]> defaultKeybindings = new Dictionary<string, string[]>() {
+            { "StartStopRecording", new string[] { "Control", "F9" } },
+            { "CreateBookmark", new string[] { "F8" } }
+        };
+
         protected Hotkey()
         {
             SetKeybind();
         }
 
-        public static Keys ParseKeys(string[] keys)
+        public static Keys ParseKeys(string keyReference, string[] keys)
         {
             Keys keybind = Keys.None;
+
+            if (keys == null) keys = AddMissingHotkey(keyReference);
+            
 
             for (int i = 0; i < keys.Length; i++)
             {
@@ -33,8 +43,17 @@ namespace RePlays.Classes.Services.Hotkeys
             return keybind;
         }
 
+        private static string[] AddMissingHotkey(string keyReference)
+        {
+            defaultKeybindings.TryGetValue(keyReference, out string[] keys);
+            SettingsService.Settings.keybindings.Add(keyReference, keys);
+            SettingsService.SaveSettings();
+            return keys;
+        }
+
         public abstract void Action();
 
+        //TODO: Refactor
         protected abstract void SetKeybind();
     }
 }

--- a/Classes/Services/Hotkeys/RecordingHotkey.cs
+++ b/Classes/Services/Hotkeys/RecordingHotkey.cs
@@ -9,6 +9,7 @@ namespace RePlays.Classes.Services.Hotkeys
 {
     public class RecordingHotkey : Hotkey
     {
+        private readonly string key = "StartStopRecording";
         public override void Action()
         {
             if (RecordingService.IsRecording) RecordingService.StopRecording();
@@ -18,8 +19,8 @@ namespace RePlays.Classes.Services.Hotkeys
         protected override void SetKeybind()
         {
             string[] keybind;
-            SettingsService.Settings.keybindings.TryGetValue("StartStopRecording", out keybind);
-            _keybind = ParseKeys(keybind);
+            SettingsService.Settings.keybindings.TryGetValue(key, out keybind);
+            _keybind = ParseKeys(key, keybind);
         }
     }
 }

--- a/Classes/Services/SettingsService.cs
+++ b/Classes/Services/SettingsService.cs
@@ -27,14 +27,7 @@ namespace RePlays.Services {
             private DetectionSettings _detectionSettings = new();
             public DetectionSettings detectionSettings { get { return _detectionSettings; } set { _detectionSettings = value; } }
 
-            public string[][][] availableKeybindings = new string[][][] { 
-                new string[][]{ new string[] { "StartStopRecording" }, new string[] { "Control", "F9" } },
-                new string[][]{ new string[] { "CreateBookmark" }, new string[] { "F8" } }
-            };
-            private Dictionary<string, string[]> _keybindings = new Dictionary<string, string[]>() { 
-                { "StartStopRecording", new string[] { "Control", "F9" } },
-                { "CreateBookmark", new string[] { "F8" } }
-            };
+            private Dictionary<string, string[]> _keybindings = new Dictionary<string, string[]>() {};
             public Dictionary<string, string[]> keybindings { get { return _keybindings; } set { _keybindings = value; } }
         }
 
@@ -43,7 +36,6 @@ namespace RePlays.Services {
                 try {
                     _Settings = JsonSerializer.Deserialize<SettingsJson>(File.ReadAllText(settingsFile));
                     Logger.WriteLine("Loaded userSettings.json");
-                    checkForMissingKeybindings();
                 }
                 catch (JsonException ex) {
                     Logger.WriteLine(ex.Message);
@@ -68,26 +60,6 @@ namespace RePlays.Services {
             var options = new JsonSerializerOptions { WriteIndented = true };
             File.WriteAllText(settingsFile, JsonSerializer.Serialize(settings, options));
             Logger.WriteLine("Saved userSettings.json");
-        }
-
-        private static void checkForMissingKeybindings(SettingsJson settings = null)
-        {
-            Logger.WriteLine("Checking for missing keybinds...");
-            if (settings == null) settings = Settings;
-            _Settings = settings;
-
-            foreach (var keybind in _Settings.availableKeybindings)
-            {
-                var key = keybind[0][0];
-                string[] value = new string[] { keybind[1][0] };
-                bool foundKey = _Settings.keybindings.ContainsKey(key);
-                if (!foundKey)
-                {
-                    Logger.WriteLine("Adding keybind " + key + " with value " + value.ToString());
-                    _Settings.keybindings.Add(key, value);
-                }
-            }
-            SaveSettings(_Settings);
         }
     }
 }

--- a/ClientApp/src/components/HotkeySelector.tsx
+++ b/ClientApp/src/components/HotkeySelector.tsx
@@ -12,8 +12,8 @@ export const HotkeySelector: React.FC<Props> = ({id, keybind, icon, width="full"
 	return (
     <div className="relative inline-block text-left dropdown">
       <button className={`bg-white dark:bg-gray-900 text-gray-700 dark:text-gray-400 border-gray-500 dark:border-gray-400 hover:text-gray-700 focus:border-blue-300
-      inline-flex justify-center w-${width} h-full px-4 py-2 text-sm font-medium leading-5 dark:text-white transition duration-150 ease-in-out border rounded-md focus:outline-none focus:shadow-outline-blue`}
-        type="button" onClick={(e) => {postMessage("EditKeybind", id);}}>
+      inline-flex justify-center w-${width} h-full px-4 py-2 text-sm font-medium leading-5 dark:text-white transition duration-150 ease-in-out border rounded-md focus:outline-none focus:shadow-outline-blue `}
+                type="button" onClick={(e) => { postMessage("EditKeybind", id); e.currentTarget.style.borderColor = "#efaf2b" }} onFocus={(e) => { postMessage("EditKeybind", id); e.currentTarget.style.borderColor = "rgba(156, 163, 175, var(--tw-border-opacity))" }}>
           {keybind?.join("+")}
           {icon && icon}
       </button>

--- a/ClientApp/src/index.tsx
+++ b/ClientApp/src/index.tsx
@@ -76,6 +76,7 @@ declare global {
   interface UserSettings {
     generalSettings: GeneralSettings
     captureSettings: CaptureSettings
+    keybindingsSettings: KeybindingsSettings
     uploadSettings: UploadSettings
     storageSettings: StorageSettings
     keybindings: Keybindings
@@ -107,6 +108,9 @@ declare global {
     inputDevicesCache: AudioDevice[],
     outputDevice: AudioDevice,
     outputDevicesCache: AudioDevice[],
+  }
+  interface KeybindingsSettings {
+      keybindings: Keybindings
   }
   interface UploadSettings {
     recentLinks: string[],

--- a/ClientApp/src/pages/Settings.tsx
+++ b/ClientApp/src/pages/Settings.tsx
@@ -37,13 +37,13 @@ export const Settings: React.FC<Props> = ({userSettings, setUserSettings}) => {
             <Link to="/settings/Capture" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">
               Capture
             </Link>
-            <Link to="/settings/detection" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">
+            <Link to="/settings/Detection" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">
               Detection
             </Link>
-            <Link to="/settings/upload" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">
+            <Link to="/settings/Upload" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">
               Upload
             </Link>
-            <Link to="/settings/storage" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">
+            <Link to="/settings/Storage" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">
               Storage
             </Link>
             <Link to="/settings/Help" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">

--- a/ClientApp/src/pages/Settings.tsx
+++ b/ClientApp/src/pages/Settings.tsx
@@ -8,6 +8,7 @@ import Help from "./Settings/Help";
 import Upload from "./Settings/Upload";
 import Detection from "./Settings/Detection"
 import { postMessage } from '../helpers/messenger';
+import Keybindings from "./Settings/Keybindings";
 
 type SettingsParams = {
   page: string;
@@ -40,6 +41,9 @@ export const Settings: React.FC<Props> = ({userSettings, setUserSettings}) => {
             <Link to="/settings/Detection" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">
               Detection
             </Link>
+            <Link to="/settings/Keybindings" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">
+              Keybindings
+            </Link>
             <Link to="/settings/Upload" className="flex items-center block py-2 px-4 rounded transition duration-100 hover:bg-gray-900 hover:text-white text-base font-medium">
               Upload
             </Link>
@@ -56,8 +60,9 @@ export const Settings: React.FC<Props> = ({userSettings, setUserSettings}) => {
           <div className="flex-auto overflow-auto h-full w-full p-7 pt-0 pb-0">
             <Switch>
               <Route exact path="/settings/general"> <General updateSettings={updateSettings} settings={userSettings?.generalSettings}/></Route>
-              <Route exact path="/settings/capture"> <Capture updateSettings={updateSettings} settings={userSettings?.captureSettings} keybindings={userSettings?.keybindings}/></Route>
-              <Route exact path="/settings/detection">  <Detection updateSettings={updateSettings} settings={userSettings?.detectionSettings}/></Route>
+              <Route exact path="/settings/capture"> <Capture updateSettings={updateSettings} settings={userSettings?.captureSettings}/></Route>
+              <Route exact path="/settings/detection">  <Detection updateSettings={updateSettings} settings={userSettings?.detectionSettings} /></Route>
+              <Route exact path="/settings/keybindings">  <Keybindings updateSettings={updateSettings} settings={userSettings?.keybindingsSettings} keybindings={userSettings?.keybindings} /></Route>
               <Route exact path="/settings/upload">  <Upload updateSettings={updateSettings} settings={userSettings?.uploadSettings}/></Route>
               <Route exact path="/settings/storage"><Storage updateSettings={updateSettings} settings={userSettings?.storageSettings}/></Route>
               <Route exact path="/settings/help">    <Help/></Route>

--- a/ClientApp/src/pages/Settings/Capture.tsx
+++ b/ClientApp/src/pages/Settings/Capture.tsx
@@ -5,10 +5,9 @@ import HotkeySelector from "../../components/HotkeySelector";
 interface Props {
   updateSettings: () => void;
   settings: CaptureSettings | undefined;
-  keybindings: Keybindings | undefined;
 }
 
-export const Capture: React.FC<Props> = ({settings, keybindings, updateSettings}) => {
+export const Capture: React.FC<Props> = ({settings, updateSettings}) => {
   const customVideoQuality = useRef<HTMLInputElement | null>(null);
   const [gameAudioVolume, setGameAudioVolume] = useState(settings!.gameAudioVolume);
   const [micAudioVolume, setMicAudioVolume] = useState(settings!.micAudioVolume);
@@ -105,23 +104,7 @@ export const Capture: React.FC<Props> = ({settings, keybindings, updateSettings}
             defaultChecked={(settings?.recordingMode === "off" ? true : false)}/>
           <span className="px-2 text-gray-700 dark:text-gray-400">Off</span>
         </label>
-      </div>
-      <div className="flex flex-col gap-1">
-        <label className="inline-flex items-center">
-          <input type="checkbox" className="form-checkbox h-4 w-4 text-gray-600"
-            defaultChecked={settings === undefined ? false : settings.useDisplayCapture}
-            onChange={(e) => {settings!.useDisplayCapture = e.target.checked; updateSettings();}}/>
-          <span className="ml-2 text-gray-700 dark:text-gray-400">Use Display Capture As Backup</span>
-        </label>
-      </div>
-      <div className="flex flex-col gap-1">
-        Toggle Recording Keybind
-        <HotkeySelector id="StartStopRecording" width="auto" keybind={keybindings?.StartStopRecording}/> 
-      </div>
-      <div className="flex flex-col gap-1">
-         Bookmark Keybind
-         <HotkeySelector id="CreateBookmark" width="auto" keybind={keybindings?.CreateBookmark} />
-      </div>
+        </div>
 
       <h1 className="font-semibold text-2xl mt-4">Video Quality</h1>
       <div className="flex gap-4" 
@@ -172,11 +155,6 @@ export const Capture: React.FC<Props> = ({settings, keybindings, updateSettings}
         </label>
       </div>
       <div className="flex gap-8">
-      <div className="flex flex-col">
-          Encoder
-          <DropDownMenu text={(settings === undefined? "x264" : settings!.encoder)} width={"auto"}
-          items={availableEncoders}/> 
-        </div>
         <div className="flex flex-col">
           Resolution
           <DropDownMenu text={(settings === undefined ? "1080p" : settings.resolution + "p")} width={"auto"}
@@ -213,9 +191,15 @@ export const Capture: React.FC<Props> = ({settings, keybindings, updateSettings}
             {name: "50 MB/s", onClick: () => {settings!.bitRate = 50; customVideoQuality.current!.checked = true; updateSettings();}},
           ]}/> 
         </div>
+        <div className="flex flex-col">
+            Encoder
+            <DropDownMenu text={(settings === undefined ? "x264" : settings!.encoder)} width={"auto"}
+                items={availableEncoders} />
+        </div>
       </div>
 
-      <h1 className="font-semibold text-2xl mt-4">Game Audio Settings</h1>
+      <h1 className="font-semibold text-2xl mt-4">Audio Settings</h1>
+      <div className="flex flex-col">Game Volume</div>
       <div className="flex gap-2">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 16 16">
           <path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.473 0 0 0-2.49-6.01l-.708.707A7.476 7.476 0 0 1 13.025 8c0 2.071-.84 3.946-2.197 5.303l.708.707z"/>
@@ -227,7 +211,7 @@ export const Capture: React.FC<Props> = ({settings, keybindings, updateSettings}
         {gameAudioVolume + "%"}
       </div>
       
-      <h1 className="font-semibold text-2xl mt-4">Microphone Audio Settings</h1>
+      <div className="flex flex-col">Microphone Volume</div>
       <div className="flex gap-2">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" fill="currentColor" viewBox="0 0 16 16">
           <path d="M11.536 14.01A8.473 8.473 0 0 0 14.026 8a8.473 8.473 0 0 0-2.49-6.01l-.708.707A7.476 7.476 0 0 1 13.025 8c0 2.071-.84 3.946-2.197 5.303l.708.707z"/>
@@ -247,6 +231,16 @@ export const Capture: React.FC<Props> = ({settings, keybindings, updateSettings}
         Input Source
         <DropDownMenu text={(settings === undefined ? "Default Device" : settings.inputDevice.deviceLabel)} width={"auto"}
         items={inputAudioDevices}/> 
+            </div>
+
+      <h1 className="font-semibold text-2xl mt-4">Advanced</h1>
+      <div className="flex flex-col gap-1">
+          <label className="inline-flex items-center">
+              <input type="checkbox" className="form-checkbox h-4 w-4 text-gray-600"
+                  defaultChecked={settings === undefined ? false : settings.useDisplayCapture}
+                  onChange={(e) => { settings!.useDisplayCapture = e.target.checked; updateSettings(); }} />
+              <span className="ml-2 text-gray-700 dark:text-gray-400">Use Display Capture As Backup</span>
+          </label>
       </div>
     </div>
 	)

--- a/ClientApp/src/pages/Settings/Keybindings.tsx
+++ b/ClientApp/src/pages/Settings/Keybindings.tsx
@@ -1,0 +1,27 @@
+﻿
+import HotkeySelector from "../../components/HotkeySelector";
+
+interface Props {
+    updateSettings: () => void;
+    settings: KeybindingsSettings | undefined;
+    keybindings: Keybindings | undefined;
+}
+
+export const Keybindings: React.FC<Props> = ({ settings, keybindings, updateSettings }) => {
+
+    return (
+        <div className="flex flex-col gap-2 font-medium text-base pb-7">
+            <h1 className="font-semibold text-2xl mt-4">Keybindings</h1>
+            <div className="flex flex-col gap-1">
+                Toggle Recording Keybind
+                <HotkeySelector id="StartStopRecording" width="auto" keybind={keybindings?.StartStopRecording} />
+            </div>
+            <div className="flex flex-col gap-1">
+                Bookmark Keybind
+                <HotkeySelector id="CreateBookmark" width="auto" keybind={keybindings?.CreateBookmark} />
+            </div>
+        </div>
+    )
+}
+
+export default Keybindings;

--- a/ClientApp/src/pages/Settings/Upload.tsx
+++ b/ClientApp/src/pages/Settings/Upload.tsx
@@ -78,7 +78,6 @@ const LocalFolder: React.FC<Props> = ({settings, updateSettings}) => {
     <div className="flex flex-col gap-2 font-medium text-base pb-7">
       <div className="font-semibold">Local Folder</div>
       <div className="flex flex-col">
-        <span className="text-gray-700 dark:text-gray-400">Game Recordings Directory</span>
         <div className="flex flex-row">
           <DirectoryBrowser id="localFolderDir" path={settings === undefined ? undefined : settings.localFolderSettings.dir}/>
           <Button text="Open Folder" width={"auto"} onClick={(e) => {postMessage("ShowFolder", (settings === undefined ? "C:\\" : settings.localFolderSettings.dir))}}/>


### PR DESCRIPTION
- Added minor fixes to title labels
- Replaced MissingHotkeys with a much better method
- Extracted keybindings to a new settings page
- Changes in "Capture" settings
  - Moved "Encoder" to the end of video quality
  - Added h1 to Audio settings and renamed the volume types
  - Moved "Use Display Capture As Backup" to a new "Advanced" label as I don't think the end user knows what is means
- Added yellow borders while editing keybindings
- Removed a misleading label in "LocalFolder"