### PR TITLE
FIX: Check if process is still active when changing to display capture.

### DIFF
--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -210,15 +210,24 @@ namespace RePlays.Recorders {
             }
             if (retryAttempt >= maxRetryAttempts) {
                 Logger.WriteLine(string.Format("Unable to get graphics hook for [{0}]", windowClassNameId));
-                var process = Process.GetProcessById(session.Pid);
-                if (SettingsService.Settings.captureSettings.useDisplayCapture && process != null && process.MainWindowHandle != IntPtr.Zero) {          
-                    Logger.WriteLine("Attempting to use display capture instead");
-                    StartDisplayCapture();
+                try
+                {
+                    var process = Process.GetProcessById(session.Pid);
+                    if (SettingsService.Settings.captureSettings.useDisplayCapture && !process.HasExited)
+                    {
+                        Logger.WriteLine("Attempting to use display capture instead");
+                        StartDisplayCapture();
+                    }
+                    else {
+                        ReleaseOutput();
+                        ReleaseSources();
+                        ReleaseEncoders();
+                        return false;
+                    }
                 }
-                else {
-                    ReleaseOutput();
-                    ReleaseSources();
-                    ReleaseEncoders();
+                catch(Exception ex)
+                {
+                    Logger.WriteLine($"Error: {ex.Message}");
                     return false;
                 }
             }

--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -210,7 +210,8 @@ namespace RePlays.Recorders {
             }
             if (retryAttempt >= maxRetryAttempts) {
                 Logger.WriteLine(string.Format("Unable to get graphics hook for [{0}]", windowClassNameId));
-                if (SettingsService.Settings.captureSettings.useDisplayCapture && Process.GetProcessById(session.Pid) != null) {
+                var process = Process.GetProcessById(session.Pid);
+                if (SettingsService.Settings.captureSettings.useDisplayCapture && process != null && process.MainWindowHandle != IntPtr.Zero) {          
                     Logger.WriteLine("Attempting to use display capture instead");
                     StartDisplayCapture();
                 }

--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -210,24 +210,29 @@ namespace RePlays.Recorders {
             }
             if (retryAttempt >= maxRetryAttempts) {
                 Logger.WriteLine(string.Format("Unable to get graphics hook for [{0}]", windowClassNameId));
+
+                Process process;
+
                 try
                 {
-                    var process = Process.GetProcessById(session.Pid);
-                    if (SettingsService.Settings.captureSettings.useDisplayCapture && !process.HasExited)
-                    {
+                    process = Process.GetProcessById(session.Pid);
+                }
+                catch {
+                    ReleaseOutput();
+                    ReleaseSources();
+                    ReleaseEncoders();
+                    return false;
+                }
+ 
+                if (SettingsService.Settings.captureSettings.useDisplayCapture && !process.HasExited)
+                {
                         Logger.WriteLine("Attempting to use display capture instead");
                         StartDisplayCapture();
-                    }
-                    else {
-                        ReleaseOutput();
-                        ReleaseSources();
-                        ReleaseEncoders();
-                        return false;
-                    }
                 }
-                catch(Exception ex)
-                {
-                    Logger.WriteLine($"Error: {ex.Message}");
+                else {
+                    ReleaseOutput();
+                    ReleaseSources();
+                    ReleaseEncoders();
                     return false;
                 }
             }

--- a/Classes/Services/DetectionService.cs
+++ b/Classes/Services/DetectionService.cs
@@ -236,7 +236,7 @@ namespace RePlays.Services {
                 process.Refresh();
 
                 int tries = 0;
-                while (tries <= 20)
+                while (tries < 40)
                 {
                     if (process.MainWindowHandle != IntPtr.Zero)
                     {
@@ -247,6 +247,7 @@ namespace RePlays.Services {
                     {
                         tries++;
                         process.Refresh();
+                        if (process.HasExited) return;
                         Logger.WriteLine($"Process [{processId}]: Got no MainWindow. Retrying... {tries}/20");
                         Thread.Sleep(1000);
                     }


### PR DESCRIPTION
Makes a check before changing to display capture to make sure that the user hasn't closed the game within the "retry" 20 seconds.
Fixes #43 .