### PR TITLE
FEAT: Rate control in settings

### DIFF
--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -31,6 +31,12 @@ namespace RePlays.Recorders {
             {"AMF", "amd_amf_h264"}
         };
 
+        private Dictionary<string, string> rate_controls = new()
+        {
+            {"VBR", "VBR"},
+            {"CBR", "CBR"}
+        };
+
         static bool signalOutputStop = false;
         static bool signalGCHookSuccess = false;
 
@@ -197,7 +203,8 @@ namespace RePlays.Recorders {
 
             // SETUP VIDEO ENCODER
             string encoder = SettingsService.Settings.captureSettings.encoder;
-            videoEncoders.TryAdd(encoder, GetVideoEncoder(encoder));
+            string rateControl = SettingsService.Settings.captureSettings.rateControl;
+            videoEncoders.TryAdd(encoder, GetVideoEncoder(encoder, rateControl));
             obs_encoder_set_video(videoEncoders[encoder], obs_get_video());
             obs_set_output_source(2, videoSources["gameplay"]);
 
@@ -289,7 +296,7 @@ namespace RePlays.Recorders {
             DisplayCapture = true;
         }
 
-        private IntPtr GetVideoEncoder(string encoder) {
+        private IntPtr GetVideoEncoder(string encoder, string rateControl) {
             IntPtr videoEncoderSettings = obs_data_create();
             obs_data_set_bool(videoEncoderSettings, "use_bufsize", true);
             obs_data_set_string(videoEncoderSettings, "profile", "high");
@@ -303,7 +310,7 @@ namespace RePlays.Recorders {
                     obs_data_set_string(videoEncoderSettings, "preset", "veryfast");
                     break;
             }
-            obs_data_set_string(videoEncoderSettings, "rate_control", "CBR");
+            obs_data_set_string(videoEncoderSettings, "rate_control", rate_controls[rateControl]);
             obs_data_set_int(videoEncoderSettings, "bitrate", (uint)SettingsService.Settings.captureSettings.bitRate * 1000);
             IntPtr encoderPtr = obs_video_encoder_create(encoder_ids[encoder], "Replays Recorder", videoEncoderSettings, IntPtr.Zero);
             obs_data_release(videoEncoderSettings);
@@ -359,6 +366,20 @@ namespace RePlays.Recorders {
             SettingsService.Settings.captureSettings.encodersCache = availableEncoders;
             if (!availableEncoders.Contains(SettingsService.Settings.captureSettings.encoder))
                 SettingsService.Settings.captureSettings.encoder = availableEncoders[0];
+            SettingsService.SaveSettings();
+        }
+
+        public void GetAvailableRateControls()
+        {
+            List<string> availableRateControls = new();
+
+            //TODO: Add more rate controls. These works in both x256 and GPU encoders.
+            availableRateControls.Add("VBR");
+            availableRateControls.Add("CBR");
+
+            SettingsService.Settings.captureSettings.rateControlCache = availableRateControls;
+            if (!availableRateControls.Contains(SettingsService.Settings.captureSettings.rateControl))
+                SettingsService.Settings.captureSettings.rateControl = availableRateControls[0];
             SettingsService.SaveSettings();
         }
 

--- a/Classes/Utils/JSONObjects.cs
+++ b/Classes/Utils/JSONObjects.cs
@@ -86,6 +86,10 @@ namespace RePlays.Utils {
         public List<string> encodersCache { get { return _encodersCache; } set { _encodersCache = value; } }
         private string _encoder = string.Empty;
         public string encoder { get { return _encoder; } set { _encoder = value; } }
+        private string _rateControl = string.Empty;
+        private List<string> _rateControlCache = new();
+        public List<string> rateControlCache { get { return _rateControlCache; } set { _rateControlCache = value; } }
+        public string rateControl { get { return _rateControl; } set { _rateControl = value; } }
         private int _resolution = 1080;
         public int resolution { get { return _resolution; } set { _resolution = value; } }
         private int _frameRate = 60;

--- a/Classes/Utils/Messages.cs
+++ b/Classes/Utils/Messages.cs
@@ -139,6 +139,7 @@ namespace RePlays.Utils {
                 case "BrowserReady": {
                         frmMain.webView2.CoreWebView2.Navigate(GetRePlaysURI());
                         ((LibObsRecorder)RecordingService.ActiveRecorder).GetAvailableEncoders(); //Another hacky fix for encoders not being loaded on first start.
+                        ((LibObsRecorder)RecordingService.ActiveRecorder).GetAvailableRateControls(); //Another hacky fix for rate conrols not being loaded on first start.
                         break;
                     }
                 case "Initialize": {

--- a/ClientApp/src/index.tsx
+++ b/ClientApp/src/index.tsx
@@ -101,7 +101,8 @@ declare global {
     resolution: number, frameRate: number, bitRate: number,
     encodersCache: string[]
     encoder: string,
-
+    rateControlCache: string[]
+    rateControl: string,
     gameAudioVolume: number,
     micAudioVolume: number,
     inputDevice: AudioDevice,

--- a/ClientApp/src/pages/Settings/Capture.tsx
+++ b/ClientApp/src/pages/Settings/Capture.tsx
@@ -14,6 +14,7 @@ export const Capture: React.FC<Props> = ({settings, updateSettings}) => {
   const [inputAudioDevices, setInputAudioDevices] = useState<any[]>();
   const [outputAudioDevices, setOutputAudioDevices] = useState<any[]>();
   const [availableEncoders, setAvailableEncoders] = useState<any[]>();
+  const [availableRateControls, setAvailableRateControls] = useState<any[]>();
 
   useEffect(() => {
     if(settings == null) return;
@@ -84,6 +85,27 @@ export const Capture: React.FC<Props> = ({settings, updateSettings}) => {
     setAvailableEncoders(ddmItems);
     return;
   }, [setAvailableEncoders]);
+
+
+    useEffect(() => {
+        if (settings == null) return;
+        if (settings.rateControlCache == null) return;
+
+        let rateControlsItems: any[] = [];
+
+        settings.rateControlCache.forEach((rateControl) => {
+
+            rateControlsItems.push({
+                name: rateControl, onClick: () => {
+                    settings.rateControl = rateControl;
+                    updateSettings();
+                }
+            });
+        });
+
+        setAvailableRateControls(rateControlsItems);
+        return;
+    }, [setAvailableRateControls]);
 
 	return (
     <div className="flex flex-col gap-2 font-medium text-base pb-7"> 
@@ -195,6 +217,11 @@ export const Capture: React.FC<Props> = ({settings, updateSettings}) => {
             Encoder
             <DropDownMenu text={(settings === undefined ? "x264" : settings!.encoder)} width={"auto"}
                 items={availableEncoders} />
+        </div>
+        <div className="flex flex-col">
+            Rate Control
+                <DropDownMenu text={(settings?.rateControl === undefined ? "VBR" : settings!.rateControl)} width={"auto"}
+                items={availableRateControls} />
         </div>
       </div>
 


### PR DESCRIPTION
Allows for selective rate controls. I've only added CBR and VBR since they both work in both CPU and GPU encoders.
Feel free to add more rate controls in the future.

I also changed the default setting to VBR because the CBR uses ALOT more storage and is primary used for streaming ([Source](https://blog.mobcrush.com/using-the-right-rate-control-in-obs-for-streaming-or-recording-4737e22895ed)).