### PR TITLE
Fixes for multiple splashscreens and AC.

### DIFF
--- a/Classes/Recorders/BaseRecorder.cs
+++ b/Classes/Recorders/BaseRecorder.cs
@@ -20,14 +20,6 @@ namespace RePlays.Recorders {
             try {
                 if(!lazy)   handle = EnumerateProcessWindowHandles(processId).First();
                 else        handle = Process.GetProcessById(processId).MainWindowHandle;
-
-                // If the windowHandle we captured is problematic, just return nothing
-                // Problematic handles are created if the application for example,
-                // the game displays a splash screen (SplashScreenClass) before launching
-                // This detection is very primative and only covers specific cases, in the future we should find another way
-                // to approach this issue. (possibily fetch to see if the window size ratio is not standard?)
-                var className = GetClassName(handle);
-                if (className.Replace(" ", "").ToLower().Contains("splashscreen")) throw new Exception($"Window handle is a possible splash screen [{className}]");
             }
             catch (Exception e) {
                 Logger.WriteLine($"There was an issue retrieving the window handle for process id [{processId}]: {e.Message}");

--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -135,7 +135,7 @@ namespace RePlays.Recorders {
 
             // attempt to retrieve process's window handle to retrieve class name and window title
             windowHandle = GetWindowHandleByProcessId(session.Pid, true);
-            while (windowHandle == IntPtr.Zero && retryAttempt < maxRetryAttempts) {
+            while ((DetectionService.HasBadWordInClassName(windowHandle) || windowHandle == IntPtr.Zero) && retryAttempt < maxRetryAttempts) {
                 Logger.WriteLine($"Waiting to retrieve process handle... retry attempt #{retryAttempt}");
                 await Task.Delay(retryInterval);
                 retryAttempt++;

--- a/Classes/Services/DetectionService.cs
+++ b/Classes/Services/DetectionService.cs
@@ -259,7 +259,7 @@ namespace RePlays.Services {
 
             if (!isGame && !executablePath.Contains(@":\Windows"))
             {
-                Logger.WriteLine($"Process [{processId}]:[{Path.GetFileName(executablePath)}] isn't in the game detection list, checking if it might be a game");
+                Logger.WriteLine($"Process [{processId}][{Path.GetFileName(executablePath)}] isn't in the game detection list, checking if it might be a game");
                 try
                 {
                     var usage = GetGPUUsage(process.Id);
@@ -267,7 +267,7 @@ namespace RePlays.Services {
                     if (usage > 10)
                     {
                         Logger.WriteLine(
-                            $"This process [{processId}]:[{Path.GetFileName(executablePath)}], appears to be a game.");
+                            $"This process [{processId}][{Path.GetFileName(executablePath)}], appears to be a game.");
                         isGame = true;
                     }
                 }
@@ -286,12 +286,12 @@ namespace RePlays.Services {
                     process.Refresh();
                     if (process.MainWindowHandle == IntPtr.Zero)
                     {
-                        Logger.WriteLine($"Process [{processId}]: Got no MainWindow. Retrying... {tries}/40");
+                        Logger.WriteLine($"Process [{processId}][{Path.GetFileName(executablePath)}]: Got no MainWindow. Retrying... {tries}/40");
                         await Task.Delay(1000);
                     }
                     else
                     {
-                        Logger.WriteLine($"Process [{processId}]: Got MainWindow [{process.MainWindowHandle}]");
+                        Logger.WriteLine($"Process [{processId}][{Path.GetFileName(executablePath)}]: Got MainWindow [{process.MainWindowTitle}]");
                         break;
                     }
                     tries++;

--- a/Classes/Services/DetectionService.cs
+++ b/Classes/Services/DetectionService.cs
@@ -30,7 +30,7 @@ namespace RePlays.Services {
         static readonly string gameDetectionsFile = Path.Join(GetCfgFolder(), "gameDetections.json");
         static readonly string nonGameDetectionsFile = Path.Join(GetCfgFolder(), "nonGameDetections.json");
         private static Dictionary<string, string> drivePaths = new();
-        private static List<string> blacklistList = new() { "splashscreen", "launcher", "cheat" };
+        private static List<string> blacklistList = new() { "splashscreen", "launcher", "cheat", "sdl_app" };
         public static void Start() {
             LoadDetections();
 

--- a/Classes/Services/DetectionService.cs
+++ b/Classes/Services/DetectionService.cs
@@ -30,7 +30,7 @@ namespace RePlays.Services {
         static readonly string gameDetectionsFile = Path.Join(GetCfgFolder(), "gameDetections.json");
         static readonly string nonGameDetectionsFile = Path.Join(GetCfgFolder(), "nonGameDetections.json");
         private static Dictionary<string, string> drivePaths = new();
-        public static List<string> splashList = new() { "splashscreen", "launcher", "cheat" };
+        private static List<string> blacklistList = new() { "splashscreen", "launcher", "cheat" };
         public static void Start() {
             LoadDetections();
 
@@ -241,9 +241,9 @@ namespace RePlays.Services {
             string gameTitle = GetGameTitle(executablePath);
 
             FileVersionInfo fileInformation = FileVersionInfo.GetVersionInfo(executablePath);
-            bool hasBadWordInDescription = fileInformation.FileDescription != null ? splashList.Where(bannedWord => fileInformation.FileDescription.ToLower().Contains(bannedWord)).Any() : false;
-            bool hasBadWordInClassName = splashList.Where(bannedWord => className.ToLower().Contains(bannedWord)).Any() || splashList.Where(bannedWord => className.ToLower().Replace(" ", "").Contains(bannedWord)).Any();
-            bool hasBadWordInGameTitle = splashList.Where(bannedWord => gameTitle.ToLower().Contains(bannedWord)).Any() || splashList.Where(bannedWord => gameTitle.ToLower().Replace(" ", "").Contains(bannedWord)).Any(); 
+            bool hasBadWordInDescription = fileInformation.FileDescription != null ? blacklistList.Where(bannedWord => fileInformation.FileDescription.ToLower().Contains(bannedWord)).Any() : false;
+            bool hasBadWordInClassName = blacklistList.Where(bannedWord => className.ToLower().Contains(bannedWord)).Any() || blacklistList.Where(bannedWord => className.ToLower().Replace(" ", "").Contains(bannedWord)).Any();
+            bool hasBadWordInGameTitle = blacklistList.Where(bannedWord => gameTitle.ToLower().Contains(bannedWord)).Any() || blacklistList.Where(bannedWord => gameTitle.ToLower().Replace(" ", "").Contains(bannedWord)).Any(); 
             if (hasBadWordInDescription || hasBadWordInClassName || hasBadWordInGameTitle) return;
 
             if (IsMatchedNonGame(executablePath)) return;
@@ -286,7 +286,7 @@ namespace RePlays.Services {
                     process.Refresh();
                     if (process.MainWindowHandle == IntPtr.Zero)
                     {
-                        Logger.WriteLine($"Process [{processId}]: Got no MainWindow. Retrying... {tries}/20");
+                        Logger.WriteLine($"Process [{processId}]: Got no MainWindow. Retrying... {tries}/40");
                         await Task.Delay(1000);
                     }
                     else
@@ -313,7 +313,7 @@ namespace RePlays.Services {
         public static bool HasBadWordInClassName(IntPtr windowHandle)
         {
             var className = ActiveRecorder.GetClassName(windowHandle);
-            bool hasBadWordInClassName = splashList.Any(bannedWord => className.ToLower().Contains(bannedWord)) || splashList.Any(bannedWord => className.ToLower().Replace(" ", "").Contains(bannedWord));
+            bool hasBadWordInClassName = blacklistList.Any(bannedWord => className.ToLower().Contains(bannedWord)) || blacklistList.Any(bannedWord => className.ToLower().Replace(" ", "").Contains(bannedWord));
             if (hasBadWordInClassName) windowHandle = IntPtr.Zero;
             return windowHandle == IntPtr.Zero;
         }


### PR DESCRIPTION
This implementation works (surprising) well on all my installed games (Yes, I tested all).
The most significant improvement is the File Description check that checks if the description includes one of the banned words (launcher, splashscreen, cheat), see photo.
![image](https://user-images.githubusercontent.com/58270063/196547960-68d02ff1-18a6-4e71-8d43-3f7e2921b9b2.png)
