### PR TITLE
Fix: Bookmarks not working if webView not initialized or gets overwritten

### DIFF
--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -14,6 +14,7 @@ namespace RePlays.Recorders
     public class LibObsRecorder : BaseRecorder {
         public bool Connected { get; private set; }
         public bool DisplayCapture;
+        public bool isStopping;
         static string videoSavePath = "";
         static string videoNameTimeStamp = "";
         static IntPtr windowHandle = IntPtr.Zero;
@@ -419,8 +420,8 @@ namespace RePlays.Recorders
         }
 
         public override async Task<bool> StopRecording() {
-            if (output == IntPtr.Zero) return false;
-
+            if (output == IntPtr.Zero || isStopping) return false;
+            isStopping = true;
             signalGCHookSuccess = false;
             var session = RecordingService.GetCurrentSession();
 
@@ -433,6 +434,7 @@ namespace RePlays.Recorders
                 await Task.Delay(retryInterval);
                 retryAttempt++;
             }
+            isStopping = false;
             if (retryAttempt >= maxRetryAttempts) {
                 return false;
             }

--- a/Classes/Services/BookmarkService.cs
+++ b/Classes/Services/BookmarkService.cs
@@ -34,16 +34,17 @@ namespace RePlays.Services
 
         public static void ApplyBookmarkToSavedVideo(string videoName)
         {
+            Logger.WriteLine($"Applying {bookmarks.Count} bookmarks");
+            if (bookmarks.Count == 0) return;
+
             try
             {
-                Logger.WriteLine($"Applying bookmarks");
                 WebMessage.SetBookmarks(videoName, bookmarks, RecordingService.lastVideoDuration);
                 bookmarks.Clear();
-                Logger.WriteLine($"Bookmark status [Successfully]");
             }
             catch (Exception e)
             {
-                Logger.WriteLine($"Bookmark status [Failed] with exception {e.Message}");
+                Logger.WriteLine($"Bookmark status: Failed with exception {e.Message}");
             }
         }
     }

--- a/Classes/Utils/Helpers.cs
+++ b/Classes/Utils/Helpers.cs
@@ -341,6 +341,45 @@ namespace RePlays.Utils {
                 return metadata;
             }
         }
+        public static void BackupBookmarks(string videoName, string json)
+        {
+            try
+            {
+                Logger.WriteLine($"Backing up bookmarks for video: {videoName}");
+                string BookmarkBackupFilePath = Path.Join(GetTempFolder(), videoName + "_bookmarks.bak");
+                Logger.WriteLine($"Backup file location: {BookmarkBackupFilePath}");
+                File.WriteAllText(BookmarkBackupFilePath, json);
+            }
+            catch(Exception ex)
+            {
+                Logger.WriteLine($"Could not backup {videoName}. Exception: {ex.Message}");
+            }
+        }
+
+        public static void LoadBackupBookmarks()
+        {
+            try
+            {
+                string[] bookmarkBackupFiles = Directory.GetFiles(GetTempFolder(), "*_bookmarks.bak", SearchOption.TopDirectoryOnly);
+                if (bookmarkBackupFiles.Length == 0) return;
+                Logger.WriteLine($"Loading {bookmarkBackupFiles.Length} bookmark backups");
+                foreach (string bookmarkBackupFile in bookmarkBackupFiles)
+                {
+                    Logger.WriteLine($"Loading {bookmarkBackupFile}");
+                    string json = File.ReadAllText(bookmarkBackupFile);
+                    WebMessage webMessage = new();
+                    webMessage.message = "SetBookmarks";
+                    webMessage.data = json;
+                    frmMain.PostWebMessageAsJson(JsonSerializer.Serialize(webMessage));
+                    File.Delete(bookmarkBackupFile);
+                    Logger.WriteLine($"Successfully applied backups for {bookmarkBackupFile}");
+                }
+            }
+            catch(Exception ex)
+            {
+                Logger.WriteLine($"Could not load backup bookmarks. Exception: {ex.Message}");
+            }
+        }
 
         public static string CreateClip(string videoPath, ClipSegment[] clipSegments, int index = 0) {
             string inputFile = Path.Join(GetPlaysFolder(), videoPath);

--- a/Classes/Utils/Messages.cs
+++ b/Classes/Utils/Messages.cs
@@ -396,14 +396,24 @@ namespace RePlays.Utils {
 
         public static void SetBookmarks(string videoName, List<Bookmark> bookmarks, double elapsed)
         {
+            string json = "{" +
+                    "\"videoname\": \"" + videoName + "\", " +
+                    "\"elapsed\": " + elapsed.ToString().Replace(",", ".") + ", " +
+                    "\"bookmarks\": " + JsonSerializer.Serialize(bookmarks) + "}";
 
-            WebMessage webMessage = new();
-            webMessage.message = "SetBookmarks";
-            webMessage.data = "{" +
-                "\"videoname\": \"" + videoName + "\", " +
-                "\"elapsed\": " + elapsed.ToString().Replace(",",".") + ", " +
-                "\"bookmarks\": " + JsonSerializer.Serialize(bookmarks) + "}";
-            SendMessage(JsonSerializer.Serialize(webMessage));
+            if (frmMain.webView2 != null)
+            {
+                WebMessage webMessage = new();
+                webMessage.message = "SetBookmarks";
+                webMessage.data = json;
+                SendMessage(JsonSerializer.Serialize(webMessage));
+                Logger.WriteLine("Successfully sent bookmarks to frontend");
+
+            }
+            else
+            {
+                BackupBookmarks(videoName, json);
+            }
         }
     }
 }

--- a/Classes/frmMain.cs
+++ b/Classes/frmMain.cs
@@ -176,6 +176,7 @@ namespace RePlays {
                     CenterToScreen();
                     firstTime = false;
                 }
+                LoadBackupBookmarks();
             }
         }
 


### PR DESCRIPTION
**First fix**
The program is mistakenly registering two instances of the game closing. As a result, it is taking the following actions:

1. Retrieve all temporary bookmarks that are meant to be set.
2. Setting the bookmarks as intended.
3. Clearing all temporary bookmarks in preparation for future recordings.
4. Attempting to retrieve all bookmarks again, but since they were cleared in step 3, the result is an empty set.
5. Setting the bookmarks a second time, which overwrites the correct bookmarks set in step 2.

This behavior is causing the program to misbehave, as it is overwriting the correct bookmarks with empty ones.

**Second fix**
You simply can't send a message to webView if it isn't initialized. So I created a backup that gets read when the webView initializes.  