### PR TITLE
set max_bitrate to match bitrate when using vbr

### DIFF
--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -385,6 +385,9 @@ namespace RePlays.Recorders {
             }
             obs_data_set_string(videoEncoderSettings, "rate_control", rate_controls[rateControl]);
             obs_data_set_int(videoEncoderSettings, "bitrate", (uint)SettingsService.Settings.captureSettings.bitRate * 1000);
+            if (SettingsService.Settings.captureSettings.rateControl == "VBR") {
+                obs_data_set_int(videoEncoderSettings, "max_bitrate", (uint)SettingsService.Settings.captureSettings.bitRate * 1000);
+            }
             IntPtr encoderPtr = obs_video_encoder_create(encoder_ids[encoder], "Replays Recorder", videoEncoderSettings, IntPtr.Zero);
             obs_data_release(videoEncoderSettings);
             return encoderPtr;


### PR DESCRIPTION
I have noticed that VBR is recording at a much lower bitrate than I expect.

When set to 15 Mb/s I see my recordings peaking at 5 Mb/s. I do not have this issue with OBS, I believe this might be because I have max bitrate to match bitrate, I figure that max bitrate being unset may be throttling the bitrate in RePlays.

I am unable to test this commit at the moment. I am not familiar with C# or the OBS libraries, however the change I made was very trivial.

If someone could build this for me to test, that would be fab!