### PR TITLE
Add 32:9 as valid resolution for recording games

### DIFF
--- a/Classes/Utils/Helpers.cs
+++ b/Classes/Utils/Helpers.cs
@@ -613,7 +613,7 @@ namespace RePlays.Utils {
         }
 
         public static bool IsValidAspectRatio(int width, int height) {
-            return new[] { "64:27", "43:18", "21:9", "16:10", "16:9", "4:3" }.Contains(GetAspectRatio(width, height));
+            return new[] { "64:27", "43:18", "21:9", "16:10", "16:9", "4:3", "32:9" }.Contains(GetAspectRatio(width, height));
         }
 
         public static IEnumerable<(T item, int index)> WithIndex<T>(this IEnumerable<T> source) {


### PR DESCRIPTION
Add 32:9 to the list of valid aspect ratios to support resolutions such as 5120x1440 and 3840x1080. Without this change only a small section of the screen is recorded.