### PR TITLE
Remove Background processes from GetTopLevelWindows

### DIFF
--- a/Classes/Services/WindowService.cs
+++ b/Classes/Services/WindowService.cs
@@ -537,7 +537,7 @@ namespace RePlays.Services {
             EnumWindows((hWnd, lParam) => {
                 GCHandle handle = GCHandle.FromIntPtr(lParam);
                 List<IntPtr> handles = (List<IntPtr>)handle.Target;
-                if (!string.IsNullOrEmpty(WindowService.GetWindowTitle(hWnd))) {
+                if (!string.IsNullOrEmpty(GetWindowTitle(hWnd))) {
                     handles.Add(hWnd);
                     return true;
                 }

--- a/Classes/Services/WindowService.cs
+++ b/Classes/Services/WindowService.cs
@@ -537,8 +537,11 @@ namespace RePlays.Services {
             EnumWindows((hWnd, lParam) => {
                 GCHandle handle = GCHandle.FromIntPtr(lParam);
                 List<IntPtr> handles = (List<IntPtr>)handle.Target;
-                handles.Add(hWnd);
-                return true;
+                if (!string.IsNullOrEmpty(WindowService.GetWindowTitle(hWnd))) {
+                    handles.Add(hWnd);
+                    return true;
+                }
+                return false;
             }, GCHandle.ToIntPtr(GCHandle.Alloc(windowHandles)));
 #endif
             return windowHandles;


### PR DESCRIPTION
Removed Background processes from GetTopLevelWindows. This should reduce lag during startup.