### PR TITLE
fix: Fixed input/output removability

### DIFF
--- a/ClientApp/src/components/AudioDevice.tsx
+++ b/ClientApp/src/components/AudioDevice.tsx
@@ -8,6 +8,7 @@ interface Props {
   onMouseUpCapture: React.MouseEventHandler<HTMLInputElement>;
   onRemove: React.MouseEventHandler<HTMLDivElement>;
   defaultValue: number;
+  isRemovable: boolean;
   item: AudioDevice;
   hasNvidiaAudioSDK: boolean;
 }
@@ -18,6 +19,7 @@ export const AudioDevice: React.FC<Props> = ({
   onMouseUpCapture,
   onRemove,
   defaultValue,
+  isRemovable,
   item,
   hasNvidiaAudioSDK,
 }) => {
@@ -30,12 +32,14 @@ export const AudioDevice: React.FC<Props> = ({
       <div className='flex flex-row gap-2'>
         <span className='whitespace-nowrap'>{item.deviceLabel}</span>
         <div className='w-full' />
-        <div
-          className={'group-hover:opacity-100 opacity-0 cursor-pointer hover:text-red-500'}
-          onClick={onRemove}
-        >
-          {t('componentsAudioDeviceItem01')}
-        </div>
+        {isRemovable && (
+          <div
+            className={'group-hover:opacity-100 opacity-0 cursor-pointer hover:text-red-500'}
+            onClick={onRemove}
+          >
+            {t('componentsAudioDeviceItem01')}
+          </div>
+        )}
       </div>
       <div className='flex flex-row gap-2'>
         <svg

--- a/ClientApp/src/pages/Settings/Capture.tsx
+++ b/ClientApp/src/pages/Settings/Capture.tsx
@@ -663,6 +663,11 @@ export const Capture: React.FC<Props> = ({ settings, updateSettings }) => {
       <div className="flex flex-col gap-4">
         {settings?.outputDevices &&
           settings.outputDevices.map((item, i) => {
+
+            const isRemovable = !(
+              settings.outputDevices.length === 1 && item.deviceId === "default"
+            );
+
             return (
               <AudioDevice
                 key={item.deviceId}
@@ -675,6 +680,7 @@ export const Capture: React.FC<Props> = ({ settings, updateSettings }) => {
                 hasNvidiaAudioSDK={
                   settings === undefined ? false : settings!.hasNvidiaAudioSDK
                 }
+                isRemovable={isRemovable}
                 onChange={(e) => {
                   let value = parseInt((e.target as HTMLInputElement).value);
                   settings!.outputDevices[i].deviceVolume = value;
@@ -702,6 +708,11 @@ export const Capture: React.FC<Props> = ({ settings, updateSettings }) => {
         {settings?.inputDevices &&
           settings.inputDevices.map((item, i) => {
             item.isInput = true;
+
+            const isRemovable = !(
+              settings.inputDevices.length === 1 && item.deviceId === "default"
+            );
+
             return (
               <AudioDevice
                 key={item.deviceId}
@@ -714,6 +725,7 @@ export const Capture: React.FC<Props> = ({ settings, updateSettings }) => {
                 hasNvidiaAudioSDK={
                   settings === undefined ? false : settings!.hasNvidiaAudioSDK
                 }
+                isRemovable={isRemovable}
                 onChange={(e) => {
                   let value = parseInt((e.target as HTMLInputElement).value);
                   settings!.inputDevices[i].deviceVolume = value;


### PR DESCRIPTION
Removed the possibility to delete the `default device` if it's the only one selected. You can still remove the `default device` if there is another item in the input/output.