### PR TITLE
refactor: Keybinding improvements

### DIFF
--- a/Classes/Services/KeybindService.cs
+++ b/Classes/Services/KeybindService.cs
@@ -32,7 +32,7 @@ namespace RePlays.Services {
             pressedKeys.Add(keyCode);
             if (EditId == null) {
                 foreach (Keybind h in keybinds) {
-                    if (string.Join(",", pressedKeys.OrderBy(s => s.ToString())) == string.Join(",", h.Keys.OrderBy(s => s.ToString())) &&
+                    if (pressedKeys.IsSupersetOf(h.Keys) &&
                         !pressedKeys.SetEquals(cachePressedKeys) && !SettingsService.Settings.keybindSettings[h.Id].disabled) {
                         h.Action();
                         Logger.WriteLine($"Key: [{string.Join(",", h.Keys)}], Action: [{h.Id}]");


### PR DESCRIPTION
- Made it possible to press the keybinding while holding another key*
- Improved speed from `O(n log n) + O(m)` to `O(n)`

\* This is useful when you might already be holding down keys for other actions (e.g., sneaking with `CTRL`) and wish to trigger the bookmark (with `F8`) without needing to release the `CTRL` key.