### PR TITLE
fix: non draggable clips

### DIFF
--- a/ClientApp/src/components/Bookmark.tsx
+++ b/ClientApp/src/components/Bookmark.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export const Bookmark = forwardRef<HTMLDivElement, Props>(
   ({ id, time = 0, type = BookmarkType.Manual }, ref) => {
-    let className = 'grid grid-flow-col absolute rounded-lg h-full bg-yellow-400';
+    let className = 'grid grid-flow-col absolute rounded-lg h-full bg-yellow-400 bookmark';
     return (
       <div
         ref={ref}

--- a/ClientApp/src/pages/Player.tsx
+++ b/ClientApp/src/pages/Player.tsx
@@ -177,20 +177,8 @@ export const Player: React.FC<Props> = ({ videos }) => {
 
     // Enables clicking on the bookmark icon.
     function findBookmarkAncestorOrSelf(element: HTMLDivElement): HTMLDivElement {
-      if (element.hasAttribute('data-index')) {
-        return element;
-      }
-
-      let parentElement: HTMLElement | null = element.parentElement;
-      while (parentElement) {
-        if (parentElement.hasAttribute('data-index')) {
-          return parentElement as HTMLDivElement;
-        }
-        parentElement = parentElement.parentElement;
-      }
-
-      // If no parent with data-index was found, return the original element
-      return element;
+      const bookmarkElement = element.closest('.bookmark');
+      return bookmarkElement as HTMLDivElement || element;
     }
 
     function handleOnMouseUp(e: MouseEvent) {


### PR DESCRIPTION
This fix addresses a problem where users couldn't drag clips. The problem started after a change I made in https://github.com/lulzsun/RePlays/pull/176. To solve this, a new bookmark class is added, and the code now checks against this class instead.