### PR TITLE
fix: Application path on update

### DIFF
--- a/Classes/Utils/Messages.cs
+++ b/Classes/Utils/Messages.cs
@@ -418,7 +418,7 @@ namespace RePlays.Utils {
                     break;
 #if WINDOWS
                 case "Restart": {
-                        string path = Path.Combine(Directory.GetParent(Directory.GetParent(Environment.ProcessPath).FullName).FullName, "RePlays.exe");
+                        string path = Path.Join(GetStartupPath(), @"../RePlays.exe");
                         string cmdCommand = $"/C timeout /t 1 & start \"\" \"{path}\"";
 
                         ProcessStartInfo processInfo = new ProcessStartInfo {

--- a/Classes/Utils/Messages.cs
+++ b/Classes/Utils/Messages.cs
@@ -418,8 +418,8 @@ namespace RePlays.Utils {
                     break;
 #if WINDOWS
                 case "Restart": {
-                        string applicationPath = Environment.ProcessPath;
-                        string cmdCommand = $"/C timeout /t 1 & start \"\" \"{applicationPath}\"";
+                        string path = Path.Combine(Directory.GetParent(Directory.GetParent(Environment.ProcessPath).FullName).FullName, "RePlays.exe");
+                        string cmdCommand = $"/C timeout /t 1 & start \"\" \"{path}\"";
 
                         ProcessStartInfo processInfo = new ProcessStartInfo {
                             FileName = "cmd.exe",


### PR DESCRIPTION
My bad.
Fixes an issue where we run the Environment.ProcessPath (`%localappdata%\RePlays\app-1.3.5\RePlays.exe`) after update instead of `%localappdata%\RePlays\RePlays.exe`.