### PR TITLE
fix: Games on the whitelist are being saved under the name "Whitelist Mode"

### DIFF
--- a/Classes/Services/DetectionService.cs
+++ b/Classes/Services/DetectionService.cs
@@ -268,7 +268,7 @@ namespace RePlays.Services {
 
         public static (bool isGame, bool forceDisplayCapture, string gameTitle) IsMatchedGame(string exeFile) {
             foreach (var game in SettingsService.Settings.detectionSettings.whitelist) {
-                if (game.gameExe == exeFile) return (true, false, game.gameName);
+                if (string.Equals(game.gameExe.ToLower(), exeFile.ToLower())) return (true, false, game.gameName);
             }
             if (SettingsService.Settings.captureSettings.recordingMode == "whitelist") return (false, false, "Whitelist Mode");
 


### PR DESCRIPTION
The issue where games on the whitelist are being saved under the name "Whitelist Mode" has been fixed. 

![image](https://github.com/lulzsun/RePlays/assets/17107119/6d211ac3-1791-4eeb-9128-0a58b594f2c1)

