### PR TITLE
fix: Skip recording for non-matched games in whitelist mode

### DIFF
--- a/Classes/Services/DetectionService.cs
+++ b/Classes/Services/DetectionService.cs
@@ -170,6 +170,8 @@ namespace RePlays.Services {
             }
             var gameDetection = IsMatchedGame(executablePath);
 
+            if (!gameDetection.isGame && SettingsService.Settings.captureSettings.recordingMode == "whitelist") { return false; }
+
             // If the windowHandle we captured is problematic, just return nothing
             // Problematic handles are created if the application for example,
             // the game displays a splash screen (SplashScreenClass) before launching


### PR DESCRIPTION
Fixes an issue where games not registered in the whitelist were being recorded, despite the whitelist mode.

Currently:

![無題](https://github.com/lulzsun/RePlays/assets/17107119/04559ff4-99f9-4164-b5a1-28d12ad8e9bc)
