### PR TITLE
fix: correct incorrect labeling of League of Legends games as Losses

### DIFF
--- a/Classes/Integrations/LeagueOfLegendsIntegration.cs
+++ b/Classes/Integrations/LeagueOfLegendsIntegration.cs
@@ -103,8 +103,12 @@ namespace RePlays.Integrations {
                     stats.Win = root.GetProperty("events").GetProperty("Events")
                         .EnumerateArray()
                         .Where(eventElement => eventElement.GetProperty("EventName").GetString() == "GameEnd")
-                        .Any(eventElement => eventElement.GetProperty("Result").GetString() == "Win");
-
+                        .Select(eventElement => eventElement.GetProperty("Result").GetString() switch {
+                            "Win" => true,
+                            "Lose" => false,
+                            _ => (bool?)null
+                        })
+                        .FirstOrDefault();
                 }
                 catch (Exception ex) {
                     if (ex.GetType() != typeof(HttpRequestException)) {
@@ -152,6 +156,6 @@ namespace RePlays.Integrations {
         public int Assists { get; set; }
         public int Deaths { get; set; }
         public string Champion { get; set; }
-        public bool Win { get; set; }
+        public bool? Win { get; set; }
     }
 }

--- a/Classes/Utils/JSONObjects.cs
+++ b/Classes/Utils/JSONObjects.cs
@@ -29,7 +29,7 @@ namespace RePlays.Utils {
         public int assists { get; set; }
         public int deaths { get; set; }
         public string champion { get; set; }
-        public bool win { get; set; }
+        public bool? win { get; set; }
     }
 
     public class VideoSortSettings {

--- a/ClientApp/src/components/Card.tsx
+++ b/ClientApp/src/components/Card.tsx
@@ -1,13 +1,12 @@
 import { useTranslation } from 'react-i18next';
-
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useContext } from 'react';
 import { Link } from 'react-router-dom';
 import { formatBytes } from '../helpers/utils';
 import { postMessage } from '../helpers/messenger';
 import UploadModal from './UploadModal';
 import { ModalContext } from '../Contexts';
 import {CompressModal} from './CompressModal';
-import {getLatestVersion} from '../integrations/league';
+import { useLatestLeagueVersion } from '../integrations/league';
 
 interface Props {
   game?: string;
@@ -45,19 +44,12 @@ export const Card: React.FC<Props> = ({
   onChange,
 }) => {
   const { t } = useTranslation();
-  const [latestVersion, setLatestVersion] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchVersion = async () => {
-      const version = await getLatestVersion();
-      setLatestVersion(version);
-    };
-    fetchVersion();
-  }, []);
+  const latestLeagueVersion = useLatestLeagueVersion(game);
 
   const modalCtx = useContext(ModalContext);
-  const resultText = win === undefined ? undefined : win ? 'Win' : 'Loss';
-  const resultColor = win === undefined ? undefined : win ? 'text-green-500' : 'text-red-500';
+  const resultText = win === null ? null : (win ? 'Win' : 'Loss');
+  const resultColor = win === null ? null : `text-${win ? 'green' : 'red'}-500`;
 
   function handleUpload() {
     console.log(`${game} ${video} ${videoType} to upload`);
@@ -179,15 +171,14 @@ export const Card: React.FC<Props> = ({
           {game === 'League of Legends' &&
             videoType === 'Sessions' &&
             champion &&
-            champion !== 'TFTChampion' && 
-            latestVersion && (
+            champion !== 'TFTChampion' && (
               <span className='absolute z-40 bottom-1 left-1 text-xs font-normal flex items-center'>
-                <img
-                  className='border border-black -mr-4 z-40 rounded-full'
-                  src={`https://ddragon.leagueoflegends.com/cdn/${latestVersion}/img/champion/${champion}.png`}
-                  style={{ width: '20px' }}
-                  alt={champion}
-                />
+                  <img
+                    className='border border-black -mr-4 z-40 rounded-full'
+                    src={`https://ddragon.leagueoflegends.com/cdn/${latestLeagueVersion}/img/champion/${champion}.png`}
+                    style={{ width: '20px' }}
+                    alt={champion}
+                  />
                 <p
                   className='py-0.5 pl-5 rounded-full p-2'
                   style={{ backgroundColor: `rgba(0, 0, 0, 0.5)` }}

--- a/ClientApp/src/integrations/league.ts
+++ b/ClientApp/src/integrations/league.ts
@@ -1,33 +1,57 @@
-﻿const LATEST_VERSION_URL = 'https://ddragon.leagueoflegends.com/api/versions.json';
+﻿import {useEffect, useState} from "react";
+
+const LATEST_VERSION_URL = 'https://ddragon.leagueoflegends.com/api/versions.json';
 
 const fetchLatestVersion = async () => {
-    const response = await fetch(LATEST_VERSION_URL);
-    const versions = await response.json();
-    return versions[0];
+  const response = await fetch(LATEST_VERSION_URL);
+  const versions = await response.json();
+  return versions[0];
 };
 
 interface VersionData {
-    latestVersion: string;
-    timestamp: number;
+  latestVersion: string;
+  timestamp: number;
 }
 
-export const getLatestVersion = async () => {
-    const versionDataString = localStorage.getItem('latestLeagueVersion');
-    const now = Date.now();
-
-    if (versionDataString) {
-        const versionData: VersionData = JSON.parse(versionDataString);
-        if (now - versionData.timestamp < 86400000) {
-            return versionData.latestVersion;
-        }
+export const fetchAndUpdateLatestLeagueVersionIfNeeded = async () => {
+  const versionDataString = localStorage.getItem('latestLeagueVersion');
+  const now = Date.now();
+  if (versionDataString) {
+    const versionData: VersionData = JSON.parse(versionDataString);
+    if (now - versionData.timestamp < 86400000) {
+      return versionData.latestVersion;
     }
+  }
 
-    const latestVersion = await fetchLatestVersion();
-    const newVersionData: VersionData = {
-        latestVersion,
-        timestamp: now,
+  const latestVersion = await fetchLatestVersion();
+  const newVersionData: VersionData = {
+    latestVersion,
+    timestamp: now,
+  };
+
+  localStorage.setItem('latestLeagueVersion', JSON.stringify(newVersionData));
+  return latestVersion;
+};
+
+export const useLatestLeagueVersion = (game: string) => {
+  const [latestLeagueVersion, setLatestLeagueVersion] = useState('');
+
+  useEffect(() => {
+    const getLatestLeagueVersionFromLocalStorage = async () => {
+      const versionData = localStorage.getItem('latestLeagueVersion');
+      if (versionData) {
+        const parsedVersionData = JSON.parse(versionData);
+        setLatestLeagueVersion(parsedVersionData.latestVersion || '');
+      } else {
+        const latestVersion = await fetchAndUpdateLatestLeagueVersionIfNeeded();
+        setLatestLeagueVersion(latestVersion);
+      }
     };
 
-    localStorage.setItem('latestLeagueVersion', JSON.stringify(newVersionData));
-    return latestVersion;
+    if (game === 'League of Legends') {
+      getLatestLeagueVersionFromLocalStorage();
+    }
+  }, [game]);
+
+  return latestLeagueVersion;
 };

--- a/ClientApp/src/pages/VideosPage.tsx
+++ b/ClientApp/src/pages/VideosPage.tsx
@@ -1,9 +1,10 @@
 import Card from '../components/Card';
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { VirtuosoGrid } from 'react-virtuoso';
-import { postMessage } from '../helpers/messenger';
+import React, {Dispatch, SetStateAction, useEffect, useState} from 'react';
+import {VirtuosoGrid} from 'react-virtuoso';
+import {postMessage} from '../helpers/messenger';
 import VideoSortControls from '../components/VideoSortControls';
 import VideoDeleteControls from '../components/VideoDeleteControls';
+import {fetchAndUpdateLatestLeagueVersionIfNeeded} from '../integrations/league';
 
 interface Props {
   videoType: string;
@@ -60,6 +61,13 @@ export const VideosPage: React.FC<Props> = ({
     }, 69); // (?) VirtuosoGrid takes too long to populate and so we need to wait a little before we set scrollPos
     return () => clearTimeout(timer);
   }, [customScrollParent]);
+
+  useEffect(() => {
+    const hasLeagueOfLegends = videos?.some((video) => video.game === 'League of Legends');
+    if (hasLeagueOfLegends) {
+      fetchAndUpdateLatestLeagueVersionIfNeeded();
+    }
+  }, [videos]);
 
   function onVideoSelected(e: React.ChangeEvent<HTMLInputElement>, index: number) {
     console.log((e.target as HTMLInputElement).checked);


### PR DESCRIPTION
- Corrected incorrect labeling of League of Legends games as Losses
- Retrieve latest LOL update only if user has a LOL recording

Partially fixes #216: It is not possible to retrieve the win-status if the user has used ALT+F4 to exit the game as the Live Game Data API has been shut down.