### PR TITLE
fix: disable incompatible replay buffer flow file formats (#207)

### DIFF
--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -227,7 +227,7 @@ namespace RePlays.Recorders {
             }
             videoNameTimeStamp = DateTime.Now.ToString("yyyy_MM_dd_HH_mm_ss");
 
-            FileFormat currentFileFormat = SettingsService.Settings.captureSettings.fileFormat ?? (new FileFormat("mp4", "MPEG-4 (.mp4)", true));
+            FileFormat currentFileFormat = SettingsService.Settings.captureSettings.fileFormat ?? (new FileFormat("mp4", "MP4 (.mp4)", true));
             Logger.WriteLine($"Output file format: " + currentFileFormat.ToString());
             videoSavePath = Path.Join(dir, videoNameTimeStamp + "-ses." + currentFileFormat.GetFileExtension());
 

--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -60,15 +60,15 @@ namespace RePlays.Recorders {
         };
 
 
-        private readonly FileFormat file_format_default = new FileFormat("fragmented_mp4", "Fragmented MP4 (.mp4)");
+        private readonly FileFormat file_format_default = new FileFormat("fragmented_mp4", "Fragmented MP4 (.mp4)", false);
         private List<FileFormat> file_formats = new() {
-            new FileFormat("fragmented_mp4", "Fragmented MP4 (.mp4)"),
-            new FileFormat("fragmented_mov", "Fragmented MOV (.mov)"),
-            new FileFormat("flv", "Flash Video (.flv)"),
-            new FileFormat("mkv", "Matroska Video (.mkv)"),
-            new FileFormat("mpegts", "MPEG-TS (.ts)"),
-            new FileFormat("mp4", "MP4 (.mp4)"),
-            new FileFormat("mov", "QuickTime (.mov)")
+            new FileFormat("fragmented_mp4", "Fragmented MP4 (.mp4)", false),
+            new FileFormat("fragmented_mov", "Fragmented MOV (.mov)", false),
+            new FileFormat("flv", "Flash Video (.flv)", false),
+            new FileFormat("mkv", "Matroska Video (.mkv)", true),
+            new FileFormat("mpegts", "MPEG-TS (.ts)", false),
+            new FileFormat("mp4", "MP4 (.mp4)", true),
+            new FileFormat("mov", "QuickTime (.mov)", true)
         };
 
         static bool signalOutputStop = false;
@@ -227,7 +227,7 @@ namespace RePlays.Recorders {
             }
             videoNameTimeStamp = DateTime.Now.ToString("yyyy_MM_dd_HH_mm_ss");
 
-            FileFormat currentFileFormat = SettingsService.Settings.captureSettings.fileFormat ?? (new FileFormat("mp4", "MPEG-4 (.mp4)"));
+            FileFormat currentFileFormat = SettingsService.Settings.captureSettings.fileFormat ?? (new FileFormat("mp4", "MPEG-4 (.mp4)", true));
             Logger.WriteLine($"Output file format: " + currentFileFormat.ToString());
             videoSavePath = Path.Join(dir, videoNameTimeStamp + "-ses." + currentFileFormat.GetFileExtension());
 

--- a/Classes/Services/SettingsService.cs
+++ b/Classes/Services/SettingsService.cs
@@ -59,7 +59,7 @@ namespace RePlays.Services {
                 ? EncryptString(data.uploadSettings.rePlaysSettings.password)
                 : Settings.uploadSettings.rePlaysSettings.password;
             if (data.captureSettings.useReplayBuffer == true && data.captureSettings.fileFormat.isReplayBufferCompatible == false) {
-                data.captureSettings.fileFormat = new FileFormat("mp4", "MPEG-4 (.mp4)", true);
+                data.captureSettings.fileFormat = new FileFormat("mp4", "MP4 (.mp4)", true);
             }
             SaveSettings(data);
         }

--- a/Classes/Services/SettingsService.cs
+++ b/Classes/Services/SettingsService.cs
@@ -58,6 +58,9 @@ namespace RePlays.Services {
                 data.uploadSettings.rePlaysSettings.password != Settings.uploadSettings.rePlaysSettings.password
                 ? EncryptString(data.uploadSettings.rePlaysSettings.password)
                 : Settings.uploadSettings.rePlaysSettings.password;
+            if (data.captureSettings.useReplayBuffer == true && data.captureSettings.fileFormat.isReplayBufferCompatible == false) {
+                data.captureSettings.fileFormat = new FileFormat("mp4", "MPEG-4 (.mp4)", true);
+            }
             SaveSettings(data);
         }
 

--- a/Classes/Utils/JSONObjects.cs
+++ b/Classes/Utils/JSONObjects.cs
@@ -155,13 +155,13 @@ namespace RePlays.Utils {
         private bool _hasNvidiaAudioSDK;
         public bool hasNvidiaAudioSDK { get { return _hasNvidiaAudioSDK; } set { _hasNvidiaAudioSDK = value; } }
 
-        private List<FileFormat> _fileFormatCache = new() { new FileFormat("mp4", "MPEG-4 (.mp4)") }; // Initially set to MP4, Updated inside LibOBSRecorder when loaded.
+        private List<FileFormat> _fileFormatCache = new() { new FileFormat("mp4", "MPEG-4 (.mp4)", true) }; // Initially set to MP4, Updated inside LibOBSRecorder when loaded.
         /// <summary>
         /// TODO: Remove cache in user settings, this is not good practice
         /// </summary>
         public List<FileFormat> fileFormatsCache { get { return _fileFormatCache; } set { _fileFormatCache = value; } }
 
-        private FileFormat _fileFormat = new FileFormat("mp4", "MPEG-4 (.mp4)");
+        private FileFormat _fileFormat = new FileFormat("mp4", "MPEG-4 (.mp4)", true);
         public FileFormat fileFormat { get { return _fileFormat; } set { _fileFormat = value; } }
 
         private bool _useReplayBuffer = false;
@@ -181,10 +181,12 @@ namespace RePlays.Utils {
     public class FileFormat {
         public string title { get; }
         public string format { get; }
+        public bool isReplayBufferCompatible { get; }
 
-        public FileFormat(string format, string title) {
+        public FileFormat(string format, string title, bool isReplayBufferCompatible) {
             this.format = format;
             this.title = title;
+            this.isReplayBufferCompatible = isReplayBufferCompatible;
         }
 
         public override string ToString() {

--- a/ClientApp/src/index.tsx
+++ b/ClientApp/src/index.tsx
@@ -126,6 +126,7 @@ declare global {
   interface FileFormat {
     title: string;
     format: string;
+    isReplayBufferCompatible: boolean;
   }
   interface CaptureSettings {
     recordingMode: string;

--- a/ClientApp/src/pages/Settings/Capture.tsx
+++ b/ClientApp/src/pages/Settings/Capture.tsx
@@ -152,6 +152,7 @@ export const Capture: React.FC<Props> = ({ settings, updateSettings }) => {
           settings.fileFormat = {
             title: 'MPEG-4 (.mp4)',
             format: 'fragmented_mp4',
+            isReplayBufferCompatible: false
           };
           updateSettings();
         },
@@ -180,6 +181,7 @@ export const Capture: React.FC<Props> = ({ settings, updateSettings }) => {
             settings.fileFormat = fmt;
             updateSettings();
           },
+          isReplayBufferCompatible: fmt.isReplayBufferCompatible
         });
       });
     }
@@ -220,10 +222,11 @@ export const Capture: React.FC<Props> = ({ settings, updateSettings }) => {
   }
 
   var current_format: any = settings?.fileFormat?.format;
-  var is_interupttable: boolean =
+  var is_interupttable: boolean = (
     current_format === 'mkv' ||
     current_format === 'fragmented_mp4' ||
-    current_format === 'fragmented_mov';
+    current_format === 'fragmented_mov') ||
+    settings?.useReplayBuffer == true;
 
 
   const validate = (e: ChangeEvent<HTMLInputElement>) => {
@@ -687,7 +690,9 @@ export const Capture: React.FC<Props> = ({ settings, updateSettings }) => {
           <DropDownMenu
             text={settings?.fileFormat === undefined ? 'MPEG-4 (.mp4)' : settings!.fileFormat.title}
             width={'auto'}
-            items={availableFileFormats}
+            items={settings?.useReplayBuffer
+              ? availableFileFormats?.filter(format => format.isReplayBufferCompatible)
+              : availableFileFormats}
           />
         </div>
       </div>


### PR DESCRIPTION
- Automatically falls back to .mp4 if an incompatible file format is chosen when enabling the replay buffer
- Only show compatible file formats in the File Format dropdown

Fixes #207.