### PR TITLE
Use game's executable as Game Title as a last resort

### DIFF
--- a/Classes/Services/DetectionService.cs
+++ b/Classes/Services/DetectionService.cs
@@ -253,6 +253,11 @@ namespace RePlays.Services {
                     if (!isWhitelistedClass && !isUserWhitelisted) return false;
                 }
                 bool allowed = SettingsService.Settings.captureSettings.recordingMode is "automatic" or "whitelist";
+                //Set game title to executable. Better than Game Unknown
+                if (gameDetection.gameTitle == "Game Unknown") {
+                    gameTitle = Path.GetFileNameWithoutExtension(executablePath);
+                    Logger.WriteLine($"Game title set to executable name: {gameTitle}");
+                }
                 Logger.WriteLine($"{(allowed ? "Starting capture for" : "Ready to capture")} application: {detailedWindowStr}");
                 RecordingService.SetCurrentSession(processId, windowHandle, gameTitle, executablePath, gameDetection.forceDisplayCapture);
                 if (allowed) RecordingService.StartRecording(false);


### PR DESCRIPTION
Use game's executable as Game Title as a last resort instead of Game Unknown when the game's title is undetected.
Basically meant for non Steam games.
This way, a bunch of undetected games don't get lumped under one single game entry.

That said, I'm going to work on implementing detection for Xbox/GamePass games (not the early UWP ones).

