### PR TITLE
fix: Delete corresponding .jpg thumbnail

### DIFF
--- a/Classes/Utils/Helpers.cs
+++ b/Classes/Utils/Helpers.cs
@@ -442,7 +442,7 @@ namespace RePlays.Utils {
 
         public static void DeleteVideo(string filePath) {
             var metaPath = Path.Join(Path.GetDirectoryName(filePath), ".thumbs/");
-            string[] metaFileExtensions = new string[] { ".png", ".webp", ".metadata" };
+            string[] metaFileExtensions = new string[] { ".png", ".jpg", ".webp", ".metadata" };
             IEnumerable<string> metaFilesToDelete = metaFileExtensions.SelectMany(ext => Directory.GetFiles(metaPath, Path.GetFileNameWithoutExtension(filePath) + ext));
 
             Logger.WriteLine($"Deleting file: {filePath}");


### PR DESCRIPTION
A fix for a bug where the `GetOrCreateThumbnail` method creates a .jpg file for thumbnail but the `DeleteVideo` method does not delete .jpg files when deleting metadata files. 