### PR TITLE
Fix: Window resizing handling

### DIFF
--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -140,7 +140,8 @@ namespace RePlays.Recorders {
                             // check to see if windowSize is different from currentSize, if so, restart recording with correct output resolution
                             Rect currentSize = WindowService.GetWindowSize(windowHandle);
                             if ((currentSize.GetWidth() > 1 && currentSize.GetHeight() > 1) && // fullscreen tabbing check
-                                (IsValidAspectRatio(currentSize.GetWidth(), currentSize.GetHeight())) && // if it is (assumed) valid game aspect ratio for recording
+                                ((IsValidAspectRatio(currentSize.GetWidth(), currentSize.GetHeight())) ||
+                                    DetectionService.UserWhitelisted) && // if it is (assumed) valid game aspect ratio or user whitelisted for recording
                                 (currentSize.GetWidth() != windowSize.GetWidth() || currentSize.GetHeight() != windowSize.GetHeight())) {
                                 RestartRecording();
                             }

--- a/Classes/Services/DetectionService.cs
+++ b/Classes/Services/DetectionService.cs
@@ -30,6 +30,8 @@ namespace RePlays.Services {
         private static List<string> classBlacklist = ["plasmashell", "splashscreen", "splashwindow", "launcher", "cheat", "console", "amddvroverlaywindowclass"];
         private static List<string> classWhitelist = ["steam_app_", "unitywndclass", "unrealwindow", "riotwindowclass"];
 
+        public static bool UserWhitelisted { get; private set; }
+
         public static void Start() {
             Logger.WriteLine("DetectionService starting...");
             LoadDetections();
@@ -239,6 +241,7 @@ namespace RePlays.Services {
                     bool isUserWhitelisted = SettingsService.Settings.detectionSettings.whitelist.Any(
                         game => string.Equals(game.gameExe.ToLower(), executablePath.ToLower())
                     );
+                    UserWhitelisted = isUserWhitelisted;
 #if !WINDOWS
                     // linux (at least proton-based) games don't have a different classname for their splashscreen.
                     // we need do check other things to see if it is a splashscreen before we record.

--- a/Classes/Services/RecordingService.cs
+++ b/Classes/Services/RecordingService.cs
@@ -188,7 +188,10 @@ namespace RePlays.Services {
         }
 
         public static async void RestartRecording() {
-            if (!IsRecording || IsRestarting) return;
+            if (!IsRecording || IsRestarting) {
+                Logger.WriteLine($"Cannot restart recording, no recording in progress or already restarting [{currentSession.Pid}][{currentSession.GameTitle}]");
+                return;
+            }
             IsRestarting = true;
 
             bool stopResultError = await ActiveRecorder.StopRecording();
@@ -201,7 +204,7 @@ namespace RePlays.Services {
             }
             else {
                 Logger.WriteLine($"Issue trying to restart recording. Could stop {!stopResultError}, could start {startResult}");
-                if (!stopResultError && !startResult) IsRecording = false;
+                StopRecording(); //Better to fully stop than end in a limbo state
             }
             IsRestarting = false;
         }


### PR DESCRIPTION
Related issue: #279 

-Fix an issue when attempting to restart recording due to the window being resized where it was comparing the opposite values of what the results should be.  (See related commit 2f7f81aaf501c02b148cf09f828897381b8cb499 )

-If restarting recording fails, it's better to do a proper stop of recording rather than just set IsRecording false state, otherwise the app gets into an inconsistent state where it will keep recording and the UI will show the recording indicator but trying to cancel recording will fail as it will think it already stopped recording and the only way to stop it is to quit the app which will also cause a corrupted file.

-Fix an issue where restarting a recording due to window size change will not be attempted if the aspect ratio is not a common one even if the game being recorded is whitelisted. (BizHawk example from OP in issue #279 ).