### PR TITLE
feat: Made tonemapping HDR to SDR a user option

### DIFF
--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -331,11 +331,13 @@ namespace RePlays.Recorders {
                 obs_data_set_string(videoSourceSettings, "capture_mode", WindowService.IsFullscreen(windowHandle) ? "any_fullscreen" : "window");
                 obs_data_set_string(videoSourceSettings, "capture_window", recordWindow);
                 obs_data_set_string(videoSourceSettings, "window", recordWindow);
-                if (WindowService.IsHdrEnabled(windowHandle)) {
-                    Logger.WriteLine("HDR is enabled, setting HDR colorspace for game_capture source");
-                    obs_data_set_string(videoSourceSettings, "rgb10a2_space", "2100pq");
+                obs_data_set_string(videoSourceSettings, "rgb10a2_space", "srgb");
+                if (captureSettings.captureHdr) {
+                    if (WindowService.IsHdrEnabled(windowHandle)) {
+                        Logger.WriteLine("HDR is enabled, setting HDR colorspace for game_capture source");
+                        obs_data_set_string(videoSourceSettings, "rgb10a2_space", "2100pq");
+                    }
                 }
-                else obs_data_set_string(videoSourceSettings, "rgb10a2_space", "srgb");
                 videoSources.TryAdd("gameplay", obs_source_create(videoSourceId, "gameplay", videoSourceSettings, IntPtr.Zero));
                 obs_data_release(videoSourceSettings);
 
@@ -846,7 +848,9 @@ namespace RePlays.Recorders {
                 range = video_range_type.VIDEO_RANGE_DEFAULT,
                 scale_type = obs_scale_type.OBS_SCALE_BILINEAR,
             };
-            if (WindowService.IsHdrEnabled(windowHandle)) obs_set_video_levels(300, 1000);
+            if (captureSettings.captureHdr) {
+                if (WindowService.IsHdrEnabled(windowHandle)) obs_set_video_levels(300, 1000);
+            }
             int resetVideoCode = obs_reset_video(ref ovi);
             if (resetVideoCode != 0) {
                 throw new Exception("error on libobs reset video: " + ((VideoResetError)resetVideoCode).ToString());

--- a/Classes/Utils/JSONObjects.cs
+++ b/Classes/Utils/JSONObjects.cs
@@ -217,6 +217,9 @@ namespace RePlays.Utils {
 
         private bool _captureGameAudio = false;
         public bool captureGameAudio { get { return _captureGameAudio; } set { _captureGameAudio = value; } }
+
+        private bool _captureHdr = false;
+        public bool captureHdr { get { return _captureHdr; } set { _captureHdr = value; } }
     }
 
     public class ClipSettings {

--- a/ClientApp/src/index.tsx
+++ b/ClientApp/src/index.tsx
@@ -162,6 +162,7 @@ declare global {
     replayBufferDuration: number;
     replayBufferSize: number;
     captureGameAudio: boolean;
+    captureHdr: boolean;
   }
 
   interface ClipSettings {

--- a/ClientApp/src/internationalization/locales/en.json
+++ b/ClientApp/src/internationalization/locales/en.json
@@ -71,6 +71,7 @@
     "settingsCaptureItem35": "Max Bitrate",
     "settingsCaptureItem36": "CQ Level",
     "settingsCaptureItem37": "Exclusively capture game audio",
+    "settingsCaptureItem38":  "Tonemap HDR content to SDR",
     "settingsClipItem01": "Re-Encode",
     "settingsClipItem02": "Encoder",
     "settingsClipItem03": "CPU: Better quality, slower encoding\nGPU: Faster encoding, lower quality",

--- a/ClientApp/src/pages/Settings/Capture.tsx
+++ b/ClientApp/src/pages/Settings/Capture.tsx
@@ -853,6 +853,20 @@ export const Capture: React.FC<Props> = ({ settings, updateSettings, device }) =
             {t('settingsCaptureItem29')}
           </span>
         </label>
+        <label className='inline-flex items-center'>
+          <input
+            type='checkbox'
+            className='form-checkbox h-4 w-4 text-gray-600'
+            defaultChecked={settings === undefined ? false : settings.captureHdr}
+            onChange={(e) => {
+              settings!.captureHdr = e.target.checked;
+              updateSettings();
+            }}
+          />
+          <span className='ml-2 text-gray-700 dark:text-gray-400'>
+            {t('settingsCaptureItem38')}
+          </span>
+        </label>
       </div>
     </div>
   );


### PR DESCRIPTION
Made capturing and tonemapping HDR to SDR into a user option under Advanced under Capture settings since
there are some cases (seems to be Unreal Engine games only) where if Windows HDR is on but the game doesn't support HDR and no alternative HDR is used on them like Auto HDR, RTX HDR or SpecialK etc., then the recording will have over saturated colors. See issue #283 