### PR TITLE
feat: Add "splashclass" to window class blacklist

### DIFF
--- a/Classes/Services/DetectionService.cs
+++ b/Classes/Services/DetectionService.cs
@@ -27,7 +27,8 @@ namespace RePlays.Services {
         static readonly HashSet<string> nonGameDetectionsCache = [];
         static readonly string gameDetectionsFile = Path.Join(GetCfgFolder(), "gameDetections.json");
         static readonly string nonGameDetectionsFile = Path.Join(GetCfgFolder(), "nonGameDetections.json");
-        private static List<string> classBlacklist = ["plasmashell", "splashscreen", "splashwindow", "launcher", "cheat", "console", "amddvroverlaywindowclass"];
+        private static List<string> classBlacklist = ["plasmashell", "splashscreen", "splashwindow", "launcher", "cheat", "console", "amddvroverlaywindowclass",
+        "splashclass"];
         private static List<string> classWhitelist = ["steam_app_", "unitywndclass", "unrealwindow", "riotwindowclass"];
 
         public static bool UserWhitelisted { get; private set; }


### PR DESCRIPTION
Fixes FF16 being captured at splash window size