### PR TITLE
Fix: Improve resolution changes handling on D3D11/12 games

### DIFF
--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -152,6 +152,31 @@ namespace RePlays.Recorders {
                         Logger.WriteLine("Successful game capture hook!");
                         signalGCHookSuccess = true;
                     }
+                    // handle resolution changes on D3D
+                    else if (formattedMsg.StartsWith("[game-capture: 'gameplay'] DXGI_SWAP_CHAIN_DESC:")) {
+                        string[] lines = formattedMsg.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                        int width = 0, height = 0;
+                        foreach (var line in lines) {
+                            if (line.Trim().StartsWith("BufferDesc.Width:")) {
+                                int.TryParse(line.Split(':')[1].Trim(), out width);
+                            }
+                            else if (line.Trim().StartsWith("BufferDesc.Height:")) {
+                                int.TryParse(line.Split(':')[1].Trim(), out height);
+                            }
+                        }
+
+                        if (width > 1 && height > 1) {
+                            Rect currentSize = new Rect(0, 0, width, height);
+                            if ((IsValidAspectRatio(currentSize.GetWidth(), currentSize.GetHeight())) ||
+                                DetectionService.UserWhitelisted) { // if it is (assumed) valid game aspect ratio or user whitelisted for recording
+                                if (currentSize.GetWidth() != windowSize.GetWidth() || currentSize.GetHeight() != windowSize.GetHeight()) {
+                                    Logger.WriteLine($"Detected resolution change to {width}x{height}. Queueing recording restart...");
+                                    RecordingService.RestartPending = true;
+                                }
+                                else RecordingService.RestartPending = false;
+                            }
+                        }
+                    }
                     else if (formattedMsg == "[game-capture: 'gameplay'] capture stopped") {
                         signalGCHookSuccess = false;
                     }
@@ -163,6 +188,11 @@ namespace RePlays.Recorders {
                         WebMessage.DisplayModal("No space left on " + SettingsService.Settings.storageSettings.videoSaveDir[..1] + ": drive. Please free up some space by deleting unnecessary files.", "Unable to save video", "warning");
                         RecordingService.StopRecording();
                     }
+                    /*if (pendingResolutionChange && signalGCHookSuccess && RecordingService.IsRecording) {
+                        Logger.WriteLine("Restarting recording due to resolution change");
+                        pendingResolutionChange = false;
+                        //RestartRecording();
+                    }*/
                 }
                 catch (Exception e) {
                     // something went wrong, most likely an issue with our sprintf implementation?

--- a/Classes/Recorders/LibObsRecorder.cs
+++ b/Classes/Recorders/LibObsRecorder.cs
@@ -188,11 +188,6 @@ namespace RePlays.Recorders {
                         WebMessage.DisplayModal("No space left on " + SettingsService.Settings.storageSettings.videoSaveDir[..1] + ": drive. Please free up some space by deleting unnecessary files.", "Unable to save video", "warning");
                         RecordingService.StopRecording();
                     }
-                    /*if (pendingResolutionChange && signalGCHookSuccess && RecordingService.IsRecording) {
-                        Logger.WriteLine("Restarting recording due to resolution change");
-                        pendingResolutionChange = false;
-                        //RestartRecording();
-                    }*/
                 }
                 catch (Exception e) {
                     // something went wrong, most likely an issue with our sprintf implementation?

--- a/Classes/Services/RecordingService.cs
+++ b/Classes/Services/RecordingService.cs
@@ -23,6 +23,8 @@ namespace RePlays.Services {
         private static bool IsRestarting { get; set; }
         public static bool GameInFocus { get; set; }
 
+        public static bool RestartPending { get; set; } = false;
+
         const int retryInterval = 2000; // 2 second
         const int maxRetryAttempts = 20; // 30 retries
 
@@ -144,6 +146,10 @@ namespace RePlays.Services {
                 if (SettingsService.Settings.captureSettings.useRecordingStartSound) {
                     Functions.PlaySound(Functions.GetResourcesFolder() + "start_recording.wav");
                 }
+                if (RestartPending) {
+                    RestartPending = false;
+                    RestartRecording();
+                }
             }
             if (!result) {
                 // recorder failed to start properly so lets restart the currentSession Pid
@@ -159,6 +165,7 @@ namespace RePlays.Services {
         }
 
         public static async void StopRecording(bool user = false) {
+            RestartPending = false;
             if (!IsRecording) {
                 Logger.WriteLine($"Cannot stop recording, no recording in progress");
                 return;
@@ -193,6 +200,7 @@ namespace RePlays.Services {
                 return;
             }
             IsRestarting = true;
+            RestartPending = false;
 
             bool stopResultError = await ActiveRecorder.StopRecording();
             bool newSession = SetSessionDetails();


### PR DESCRIPTION
Helps issues #286 and #289

Monitor libOBS output and when it gets the DXGI swapchain info, compare width and height with the previously detected window dimensions and if it differs, queue up a recording restart to re-detect.

Note that this will, in most cases, result in a less than one second session being recorded with the wrong resolution, if the resolution changes happen at startup, like in the Battlefield games. Maybe we could cleanup these less than a second sessions?
